### PR TITLE
Add Color::intValue() to convert colors to ARGB color ints

### DIFF
--- a/src/main/php/img/Color.class.php
+++ b/src/main/php/img/Color.class.php
@@ -3,40 +3,49 @@
 /**
  * Color class
  *
- * @test  xp://net.xp_framework.unittest.img.ColorTest
- * @see   xp://img.Image
+ * @test  img.unittest.ColorTest
+ * @see   img.Image
  */
 class Color {
-  public
-    $red      = 0,
-    $green    = 0,
-    $blue     = 0;
-    
-  public
-    $handle     = null;
+  public $reg, $green, $blue;
+  public $handle= null;
   
   /**
-   * Constructor
+   * Creates a new color. Three forms are acceptable:
    *
-   * @param   var a string containing the hexadecimal format or
-   *          three ints (red, green blue)
+   * ```php
+   * new Color('#990000');    // from hex
+   * new Color(255, 0, 255);  // from rgb components
+   * new Color(0xffa7ff03);   // from ARGB color integer
+   * ```
+   *
+   * @param  var... $args
+   * @see    https://developer.android.com/reference/android/graphics/Color#color-ints
    */
-  public function __construct() {
-    $a= func_get_args();
-    if (is_string($a[0])) {
-      sscanf(ltrim($a[0], '#'), '%2x%2x%2x', $this->red, $this->green, $this->blue);
+  public function __construct(... $args) {
+    if (3 === sizeof($args)) {
+      list($this->red, $this->green, $this->blue)= $args;
+    } else if (is_int($input= $args[0])) {
+      $this->red= ($input >> 16) & 0xff;
+      $this->green= ($input >> 8) & 0xff;
+      $this->blue= $input & 0xff;
     } else {
-      list($this->red, $this->green, $this->blue)= $a;
+      sscanf(ltrim($input, '#'), '%2x%2x%2x', $this->red, $this->green, $this->blue);
     }
+  }
+
+  /** Compresses this color into an ARGB integer */
+  public function intValue(): int {
+    return (255 & 0xff) << 24 | ($this->red & 0xff) << 16 | ($this->green & 0xff) << 8 | ($this->blue & 0xff);
   }
   
   /**
-   * Get RGB value as hexadecimal string (e.g. #990000)
+   * Get RGB value as hexadecimal string, e.g. `#990000`.
    *
-   * @return  string HTML-style color
+   * @return string
    */
   public function toHex() {
-    return '#'.dechex($this->red).dechex($this->green).dechex($this->blue);
+    return sprintf('#%02x%02x%02x', $this->red, $this->green, $this->blue);
   }
   
   /**

--- a/src/main/php/img/Color.class.php
+++ b/src/main/php/img/Color.class.php
@@ -7,7 +7,7 @@
  * @see   img.Image
  */
 class Color {
-  public $reg, $green, $blue;
+  public $red, $green, $blue;
   public $handle= null;
   
   /**

--- a/src/test/php/img/unittest/ColorTest.class.php
+++ b/src/test/php/img/unittest/ColorTest.class.php
@@ -35,4 +35,9 @@ class ColorTest extends TestCase {
   public function argb_color_int($argb) {
     $this->assertEquals($argb, (new Color($argb))->intValue());
   }
+
+  #[Test]
+  public function argb_signed_32_bit() {
+    $this->assertEquals(0xff464d32, (new Color(-12169934))->intValue());
+  }
 }

--- a/src/test/php/img/unittest/ColorTest.class.php
+++ b/src/test/php/img/unittest/ColorTest.class.php
@@ -1,20 +1,15 @@
 <?php namespace img\unittest;
 
 use img\Color;
-use unittest\{Test, Values};
+use unittest\{Test, TestCase, Values};
 
-/**
- * TestCase
- *
- * @see   xp://img.Color
- */
-class ColorTest extends \unittest\TestCase {
+class ColorTest extends TestCase {
 
   #[Test, Values(['#a7ff03', 'a7ff03', 'A7FF03', '#A7FF03'])]
   public function create_from_hex($value) {
     $c= new Color($value);
-    $this->assertEquals(0xA7, $c->red);
-    $this->assertEquals(0xFF, $c->green);
+    $this->assertEquals(0xa7, $c->red);
+    $this->assertEquals(0xff, $c->green);
     $this->assertEquals(0x03, $c->blue);
   }
 
@@ -34,5 +29,10 @@ class ColorTest extends \unittest\TestCase {
   #[Test]
   public function string_representation() {
     $this->assertEquals('img.Color@(239, 010, 007)', (new Color('#ef0a07'))->toString());
+  }
+
+  #[Test, Values([0xff000000, 0xffa7ff03, 0xffffffff])]
+  public function argb_color_int($argb) {
+    $this->assertEquals($argb, (new Color($argb))->intValue());
   }
 }


### PR DESCRIPTION
## Working with the color int

Instances can now be created in three ways:

```php
new Color('#990000');    // from hex
new Color(255, 0, 255);  // from rgb components
new Color(0xffa7ff03);   // from ARGB color integer
```

The color int can be retrieved via *intValue()*:

```php
$color= new Color(0xffa7ff03);
$argb= $color->intValue();
```

## ARGB

> ### Encoding
> The four components of a color int are encoded in the following way:
>
> ```c
> int color = (A & 0xff) << 24 | (R & 0xff) << 16 | (G & 0xff) << 8 | (B & 0xff);
> ```
>
> Because of this encoding, color ints can easily be described as an integer constant in source. For instance, opaque blue is 0xff0000ff and yellow is 0xffffff00.

See https://developer.android.com/reference/android/graphics/Color#color-ints