### PR TITLE
Drop dependency on XML library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^12.0 | ^11.0 | ^10.0",
-    "xp-framework/xml" : "^12.0 | ^11.0 | ^10.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/test/php/img/unittest/MetaDataReaderTest.class.php
+++ b/src/test/php/img/unittest/MetaDataReaderTest.class.php
@@ -1,17 +1,12 @@
 <?php namespace img\unittest;
 
+use DOMDocument;
 use img\ImagingException;
 use img\io\{CommentSegment, MetaDataReader, SOFNSegment, XMPSegment};
 use test\{Assert, Before, Expect, Test};
-use xml\Node;
 
-/**
- * TestCase for MetaDataReader class
- *
- * @see  xp://img.io.MetaDataReader
- */
 class MetaDataReaderTest {
-  protected $fixture;
+  private $fixture;
 
   /**
    * Sets up this unittest 
@@ -108,7 +103,9 @@ class MetaDataReaderTest {
   public function xmp_segment() {
     $segments= $this->extractFromFile('xmp.jpg')->segmentsOf('img.io.XMPSegment');
     $this->assertArrayOf('img.io.XMPSegment', 1, $segments);
-    Assert::instance(Node::class, $segments[0]->document()->getElementsByTagName('dc:title')[0]);
+
+    Assert::matches('/^<.+/', $segments[0]->source);
+    Assert::instance(DOMDocument::class, $segments[0]->document());
   }
 
   #[Test]


### PR DESCRIPTION
This pull request changes `XMPSegment::document()` to use the built-in `DOMDocument` class instead of the XP Framework's XML library, making this library more light-weight to use.

⚠️ This is a BC break and will result in a major version being released!