### PR TITLE
Make it possible to set default time zone for EXIF / IPTC data

### DIFF
--- a/src/test/php/img/unittest/MetaDataReaderTest.class.php
+++ b/src/test/php/img/unittest/MetaDataReaderTest.class.php
@@ -4,7 +4,6 @@ use DOMDocument;
 use img\ImagingException;
 use img\io\{Segment, CommentSegment, MetaDataReader, SOFNSegment, XMPSegment, ExifSegment, IptcSegment};
 use img\util\{ExifData, IptcData};
-use lang\ArrayType;
 use test\{Assert, Before, Expect, Test, Values};
 use util\{Date, TimeZone};
 


### PR DESCRIPTION
This pull request adds an optional parameter to `exifData()` and `iptcData()` in `img.io.ImageMetaData`.

## Example

```php
use img\io\MetaDataReader;
use io\streams\FileInputStream;
use util\TimeZone;

$reader= new MetaDataReader();
$meta= $reader->read(new FileInputStream($argv[1]));

// Uses the supplied time zone 
$exif= $meta->exifData(new TimeZone('Asia/Muscat'));

// If omitted, uses system's local timezone
$exif= $meta->exifData();
```

## Progress

* [x] Make it possible to optionally pass timezones
* [x] Fix IPTC created date not including time, see https://iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#date-created